### PR TITLE
add reference to body-parser

### DIFF
--- a/examples/ex1.webhook.js
+++ b/examples/ex1.webhook.js
@@ -2,6 +2,7 @@
 
 const TeaBot = require('../main')('YOUR_TELEGRAM_BOT_TOKEN', 'YOUR_TELEGRAM_BOT_NAME');
 const express = require('express');
+const bodyParser = require('body-parser');
 const app = express();
 
 TeaBot.onError(function (e) {
@@ -15,6 +16,11 @@ TeaBot
   .defineCommand(function (dialog) {
     dialog.sendMessage('Send me /help for more information.');
   });
+
+app.use(bodyParser.urlencoded({
+  extended: true
+}));
+app.use(bodyParser.json());
 
 TeaBot.setWebhook('YOUR_URL_HERE');
 


### PR DESCRIPTION
This example did not work for me until I added body-parser. Without it, the `message` in `app.post` was always `undefined`.
